### PR TITLE
Add nodejs buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -53,6 +53,9 @@
   ],
   "buildpacks": [
     {
+      "url": "heroku/nodejs"
+    },
+    {
       "url": "https://github.com/jontewks/puppeteer-heroku-buildpack"
     }
   ]


### PR DESCRIPTION
Should fix #7 for new/fresh deployments - existing deployments should ensure App > Settings > Buildpacks has the Nodejs and puppeteer build backs listed before deployment (in that order) 