### PR TITLE
fix: Uses newer lodash version for history graph deep clone

### DIFF
--- a/lib/history-graph.js
+++ b/lib/history-graph.js
@@ -1,5 +1,5 @@
 const dateFormat = require('dateformat');
-const cloneDeep = require('lodash.clonedeep');
+const cloneDeep = require('lodash/cloneDeep');
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 const V = require('victory');

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.16.4",
     "google-libphonenumber": "^3.2.1",
     "load-json-file": "^5.1.0",
+    "lodash": "^4.17.15",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.1",
     "mailgun-js": "^0.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,6 +3249,11 @@ lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"


### PR DESCRIPTION
Fixes #55. ~I don't have a full understanding of the surrounding code, but the error I was getting seemed to be due to lodash's `cloneDeep` method not playing nicely with the CoreMongoose Array that we're now working with. Creating an array from that CoreMongoose array allows lodash to play nicely with it. `Array.from` only does a shallow clone, so we still need to deeply clone it before mucking with it to display the graph.~

@brussrus pointed out that the `lodash.clonedeep` module was using an older version of lodash (4.5). The project was already bundling lodash (4.17) via other dependencies, so I made that dependency explicit and used that instead of the old one. Long-term it might make sense to fully remove the `lodash.clonedeep` dependency, I think it's only used in one place.