### PR TITLE
Updated Readme for PROXY value format

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Instructions on deploying a proxy is outside the scope of this project. However,
   http_access allow swa
   http_access deny all
   ```
-To configure the Price Drop Bot to use your proxy, define a new `PROXY` variable within the Heroku Config. The proxy format should just be IP:port. Example: `heroku config:set PROXY='123.123.123.123:1234'`
+To configure the Price Drop Bot to use your proxy, define a new `PROXY` variable within the Heroku Config. The proxy format should be http://IP:port. Example: `heroku config:set PROXY='http://123.123.123.123:1234'`
 
 ## Development
 


### PR DESCRIPTION
Proxy format needs to include http:// to avoid error. Updated docs to mention this.