### PR TITLE
fix: Updates .get call in change price route

### DIFF
--- a/lib/apps/app.js
+++ b/lib/apps/app.js
@@ -141,7 +141,7 @@ app.get('/:id', async (req, res) => {
 
 // CHANGE PRICE
 app.get('/:id/change-price', async (req, res) => {
-  const alert = await Alert.find(req.params.id);
+  const alert = await Alert.get(req.params.id);
 
   if (!alert) {
     const errorMsg = 'Unable to change price. Invalid id: ' + req.params.id;


### PR DESCRIPTION
It looks like `.get` is the call to fetch an alert (per the normal `/:id` route in the same file). Tested on my instance and it seems to work.